### PR TITLE
removed google-blockly submodule and files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "st/REST"]
 	path = st/REST
 	url = https://github.com/RichoM/REST
-[submodule "web/blockly/google-blockly"]
-	path = web/blockly/google-blockly
-	url = https://github.com/RichoM/blockly.git
 [submodule "web/filesaver"]
 	path = web/filesaver
 	url = https://github.com/RichoM/FileSaver.js


### PR DESCRIPTION
This is work in progress to fix #4:
  * [x] remove the submodule and its files.
  * [ ] update google-blockly files in `/web/ide/libs/google-blockly/` to release `3.20191014.4`

I stumbled upon the folder `/web/blockly`, is this used for the generator code? As I understood, the pure library code of blockly lies in folder `/web/ide/libs/google-blockly/`?