### PR TITLE
tried changing block 'number-random-int' to allow re-ording of fields

### DIFF
--- a/web/ide/blocks.js
+++ b/web/ide/blocks.js
@@ -834,9 +834,9 @@ let UziBlock = (function () {
 
     Blockly.Blocks['number_random_int'] = {
       init: function() {
-        let msg = i18n.translate("random integer from % to %");
-        let parts = msg.split("%").map(trim);
-        let inputs = [
+        let msg = i18n.translate("random integer from %0 to %1");
+        let parts = msg.split(" ").map(trim);
+        let inputFields = [
           this.appendValueInput("from")
             .setCheck("Number")
             .setAlign(Blockly.ALIGN_RIGHT),
@@ -844,11 +844,18 @@ let UziBlock = (function () {
              .setCheck("Number")
              .setAlign(Blockly.ALIGN_RIGHT)
         ];
+        let isInputField = /^%\d+$/; // for testing %1, %2 etc
         for (let i = 0; i < parts.length; i++) {
-          let input = i < inputs.length ? inputs[i] : this.appendDummyInput();
           let part = parts[i];
-          input.appendField(part);
+          if (isInputField.test(part)) { // if translation part is an input field
+            let fieldNumber = Number(part.substring(1)); // convert to int
+            let inputField = inputFields[fieldNumber]; // get correct input field
+            inputField.appendField(); // not sure?
+          } else {
+            this.appendDummyInput().appendField(part); // not sure
+          }
         }
+	    
         this.setInputsInline(true);
         this.setOutput(true, "Number");
         this.setColour(230);

--- a/web/ide/blocks.js
+++ b/web/ide/blocks.js
@@ -836,23 +836,30 @@ let UziBlock = (function () {
       init: function() {
         let msg = i18n.translate("random integer from %0 to %1");
         let parts = msg.split(" ").map(trim);
-        let inputFields = [
-          this.appendValueInput("from")
-            .setCheck("Number")
-            .setAlign(Blockly.ALIGN_RIGHT),
-          this.appendValueInput("to")
-             .setCheck("Number")
-             .setAlign(Blockly.ALIGN_RIGHT)
-        ];
-        let isInputField = /^%\d+$/; // for testing %1, %2 etc
+        let isInputField = /^%\d+$/; // for testing references %1, %2 etc
+
         for (let i = 0; i < parts.length; i++) {
           let part = parts[i];
-          if (isInputField.test(part)) { // if translation part is an input field
+          if (isInputField.test(part)) { // if part is an input field reference
             let fieldNumber = Number(part.substring(1)); // convert to int
-            let inputField = inputFields[fieldNumber]; // get correct input field
-            inputField.appendField(); // not sure?
+
+            switch (fieldNumber) {
+	      case 0:
+		  this.appendValueInput("from")
+		      .setCheck("Number")
+		      .setAlign(Blockly.ALIGN_RIGHT);
+		  break;
+	      case 1:
+		  this.appendValueInput("to")
+		      .setCheck("Number")
+		      .setAlign(Blockly.ALIGN_RIGHT);
+		  break;
+	      default:
+		  console.debug("Non-existing field number referenced in translation for 'number_random_int'");
+		  break;
+	      }
           } else {
-            this.appendDummyInput().appendField(part); // not sure
+              this.appendDummyInput().appendField(part); // not sure why appendDummyInput is needed
           }
         }
 	    

--- a/web/ide/translations.js
+++ b/web/ide/translations.js
@@ -121,7 +121,7 @@ var TRANSLATIONS = [
     ["Comments", "Comentarios", "Kommentaarid"],
     ["Configure DC motors...", "Configurar motores CC...", "Seadista mootorid..."],
     ["Configure sonars...", "Configurar sonares...", "Seadista kajalood..."],
-    ["random integer from % to %", "número entero al azar entre % y %", "suvaline täisarv % ja % vahel"],
+    ["random integer from %0 to %1", "número entero al azar entre %0 y %1", "suvaline täisarv %0 ja %1 vahel"],
     ["constrain % low % high %", "mantener % entre % y %", "piira % madal % kõrge %"],
     ["random fraction", "fracción al azar", "suvaline murdarv"],
     ["square root", "raíz cuadrada", "ruutjuur"],


### PR DESCRIPTION
**This does not work yet, don't merge it!**

My aim is to allow translations reorder the input fields, but this is not working yet. I think the definiton of the input fields (on line 839) creates the input fields before the code goes through the `msg`.